### PR TITLE
Remove favicon reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
 <meta name="twitter:image"       content="https://elpulqui.github.io/encuesta/og-cover.jpg">
 
 <!-- Favicon (se muestra en la pestaña del navegador) -->
-<link rel="icon" type="image/png" sizes="32x32" href="favicon.png">
 <link rel="stylesheet" href="style.css">
 
 <!-- Supabase: ajustar sólo URL y KEY si cambian -->


### PR DESCRIPTION
## Summary
- clean up index.html to avoid referencing a missing favicon

## Testing
- `grep -n favicon index.html`

------
https://chatgpt.com/codex/tasks/task_e_684061dd948c8332974cf8d77f8aa98f