### PR TITLE
Fix meta tag syntax error

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <meta property="og:description" content="Tu opinión mejora nuestro servicio. ¡Completá la encuesta en 1 minuto!">
 <meta property="og:image"       content="https://elpulqui.github.io/encuesta/og-cover.jpg">
 <meta property="og:image:width" content="1200">
-<meta property="og:image:height"content="630">
+<meta property="og:image:height" content="630">
 
 <!-- Twitter (opcional) -->
 <meta name="twitter:card"        content="summary_large_image">


### PR DESCRIPTION
## Summary
- fix missing space in Open Graph meta tag

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68402c79015083329aabeee5b6249cef